### PR TITLE
fix: remove unsupported columns.

### DIFF
--- a/collector/pg_replication_slot_test.go
+++ b/collector/pg_replication_slot_test.go
@@ -31,9 +31,9 @@ func TestPgReplicationSlotCollectorActive(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
+	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "wal_status"}
 	rows := sqlmock.NewRows(columns).
-		AddRow("test_slot", "physical", 5, 3, true, 323906992, "reserved")
+		AddRow("test_slot", "physical", 5, 3, true, "reserved")
 	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -50,7 +50,6 @@ func TestPgReplicationSlotCollectorActive(t *testing.T) {
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 5, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 3, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 1, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 323906992, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical", "wal_status": "reserved"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}
 
@@ -74,9 +73,9 @@ func TestPgReplicationSlotCollectorInActive(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
+	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "wal_status"}
 	rows := sqlmock.NewRows(columns).
-		AddRow("test_slot", "physical", 6, 12, false, -4000, "extended")
+		AddRow("test_slot", "physical", 6, 12, false, "extended")
 	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -92,7 +91,6 @@ func TestPgReplicationSlotCollectorInActive(t *testing.T) {
 	expected := []MetricResult{
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 6, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: 0, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical"}, value: -4000, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"slot_name": "test_slot", "slot_type": "physical", "wal_status": "extended"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}
 
@@ -117,9 +115,9 @@ func TestPgReplicationSlotCollectorActiveNil(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
+	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "wal_status"}
 	rows := sqlmock.NewRows(columns).
-		AddRow("test_slot", "physical", 6, 12, nil, nil, "lost")
+		AddRow("test_slot", "physical", 6, 12, nil, "lost")
 	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -158,9 +156,9 @@ func TestPgReplicationSlotCollectorTestNilValues(t *testing.T) {
 
 	inst := &instance{db: db}
 
-	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
+	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "wal_status"}
 	rows := sqlmock.NewRows(columns).
-		AddRow(nil, nil, nil, nil, true, nil, nil)
+		AddRow(nil, nil, nil, nil, true, nil)
 	mock.ExpectQuery(sanitizeQuery(pgReplicationSlotQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)

--- a/collector/pg_stat_database_test.go
+++ b/collector/pg_stat_database_test.go
@@ -52,7 +52,6 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 		"deadlocks",
 		"blk_read_time",
 		"blk_write_time",
-		"active_time",
 		"stats_reset",
 	}
 
@@ -81,7 +80,6 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 			925,
 			16,
 			823,
-			33,
 			srT)
 
 	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery)).WillReturnRows(rows)
@@ -115,7 +113,6 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 925},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 16},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 823},
-		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0.033},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 1685059842},
 	}
 
@@ -162,7 +159,6 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 		"deadlocks",
 		"blk_read_time",
 		"blk_write_time",
-		"active_time",
 		"stats_reset",
 	}
 
@@ -186,7 +182,6 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 			925,
 			16,
 			823,
-			32,
 			srT).
 		AddRow(
 			"pid",
@@ -207,7 +202,6 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 			925,
 			16,
 			823,
-			32,
 			srT)
 	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery)).WillReturnRows(rows)
 
@@ -240,7 +234,6 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 925},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 16},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 823},
-		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0.032},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 1685059842},
 	}
 
@@ -282,7 +275,6 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 		"deadlocks",
 		"blk_read_time",
 		"blk_write_time",
-		"active_time",
 		"stats_reset",
 	}
 
@@ -311,10 +303,8 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 			925,
 			16,
 			823,
-			14,
 			srT).
 		AddRow(
-			nil,
 			nil,
 			nil,
 			nil,
@@ -354,7 +344,6 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 			926,
 			17,
 			824,
-			15,
 			srT)
 	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery)).WillReturnRows(rows)
 
@@ -387,7 +376,6 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 925},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 16},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 823},
-		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0.014},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 1685059842},
 
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_GAUGE, value: 355},
@@ -406,7 +394,6 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 926},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 17},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 824},
-		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0.015},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 1685059842},
 	}
 
@@ -449,7 +436,6 @@ func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 		"deadlocks",
 		"blk_read_time",
 		"blk_write_time",
-		"active_time",
 		"stats_reset",
 	}
 
@@ -473,7 +459,6 @@ func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 			925,
 			16,
 			823,
-			7,
 			nil)
 
 	mock.ExpectQuery(sanitizeQuery(statDatabaseQuery)).WillReturnRows(rows)
@@ -507,7 +492,6 @@ func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 925},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 16},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 823},
-		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0.007},
 		{labels: labelMap{"datid": "pid", "datname": "postgres"}, metricType: dto.MetricType_COUNTER, value: 0},
 	}
 


### PR DESCRIPTION
Removing colums unsupported for versions of Postgres < v14 in database and replication_clot collectors.