### PR TITLE
fix: dsn fingerprint parsing

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -415,7 +415,7 @@ type Exporter struct {
 	userQueriesPath  string
 	constantLabels   prometheus.Labels
 	duration         prometheus.Gauge
-	errors            prometheus.Gauge
+	errors           prometheus.Gauge
 	psqlUp           prometheus.Gauge
 	userQueriesError *prometheus.GaugeVec
 	totalScrapes     prometheus.Counter

--- a/cmd/postgres_exporter/postgres_exporter_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_test.go
@@ -230,6 +230,10 @@ func (s *FunctionalSuite) TestParseFingerprint(c *C) {
 			fingerprint: "localhost:55432",
 		},
 		{
+			url:         "postgresql://userDsn:passwordDsn%3D@localhost:55432/foo?sslmode=disabled&options=-c%20statement_timeout%3D3min%20-c%20statement_timeout%3D1min",
+			fingerprint: "localhost:55432",
+		},
+		{
 			url:         "port=1234",
 			fingerprint: "localhost:1234",
 		},

--- a/cmd/postgres_exporter/util.go
+++ b/cmd/postgres_exporter/util.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -177,7 +178,12 @@ func parseFingerprint(url string) (string, error) {
 		dsn = url
 	}
 
-	pairs := strings.Split(dsn, " ")
+	re, _ := regexp.Compile(`[a-z_]+=(?:(?:'[^']+')|(?:[^\s]+))`)
+	pairs := re.FindAllString(dsn, -1)
+	if pairs == nil {
+		return "", fmt.Errorf("malformed dsn %q", dsn)
+	}
+
 	kv := make(map[string]string, len(pairs))
 	for _, pair := range pairs {
 		splitted := strings.SplitN(pair, "=", 2)


### PR DESCRIPTION
Multiple values in the 'options' parameter was causing false positive errors.
Replaced with a less naive regular expression.